### PR TITLE
Suggested changes to Shallow_tracer_pyclaw.ipynb

### DIFF
--- a/Shallow_tracer_pyclaw.ipynb
+++ b/Shallow_tracer_pyclaw.ipynb
@@ -61,8 +61,15 @@
    },
    "outputs": [],
    "source": [
-    "!f2py -c rp1_shallow_roe_tracer.f90 -m shallow_roe_tracer > temp\n",
+    "!f2py -c rp1_shallow_roe_tracer.f90 -m shallow_roe_tracer > f2py_output.txt\n",
     "import shallow_roe_tracer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The previous cell uses [f2py](https://docs.scipy.org/doc/numpy-dev/f2py/) to convert the Fortran Riemann solver into a Python function.  You can see the output from running this command in the file [f2py_output.txt](f2py_output.txt)."
    ]
   },
   {
@@ -155,6 +162,7 @@
     "plt.ylabel('depth ($h$)')\n",
     "plt.axis('scaled')\n",
     "ax1.set_xlim(-1,1)\n",
+    "ax1.set_ylim(0,1.2)\n",
     "\n",
     "def fplot(frame_number):\n",
     "    for i in range(4):\n",
@@ -202,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
added:
ylim to plot, 
link to f2py and to text file where compilation output is recorded.

Question: What does the slicing `tracer%0.1` mean and why is this needed in the `fill_between` plots?