### PR TITLE
Shallow_water: add plots in h-u plane

### DIFF
--- a/Shallow_water.ipynb
+++ b/Shallow_water.ipynb
@@ -157,7 +157,7 @@
     "def plot_hugoniot_loci(plot_1=True,plot_2=False):\n",
     "    h = np.linspace(0.01,3)\n",
     "    hstar = 1.0\n",
-    "    for hustar in np.linspace(-2,2,10):\n",
+    "    for hustar in np.linspace(-4,4,15):\n",
     "        if plot_1:\n",
     "            hu = shallow_water.hugoniot_locus(h,hstar,hustar,wave_family=1)\n",
     "            plt.plot(h,hu,'-',color='coral')\n",
@@ -165,9 +165,56 @@
     "            hu = shallow_water.hugoniot_locus(h,hstar,hustar,wave_family=2)\n",
     "            plt.plot(h,hu,'-',color='maroon')\n",
     "        plt.axis((0,3,-3,3))\n",
+    "        plt.xlabel('depth h')\n",
+    "        plt.ylabel('momentum hu')\n",
+    "        plt.title('Hugoniot loci')\n",
     "    plt.show()\n",
     "\n",
     "interact(plot_hugoniot_loci);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plot above shows the Hugoniot loci in the $h$-$hu$ plane, the natural phase plane in terms of the two conserved quantities.  Note that they all approach the origin as $h \\rightarrow 0$. Alternatively, we can plot these same curves in the $h$-$u$ plane:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def plot_hugoniot_loci_u(plot_1=True,plot_2=False):\n",
+    "    h = np.linspace(0.001,3,100)\n",
+    "    hstar = 1.0\n",
+    "    for ustar in np.linspace(-4,4,15):\n",
+    "        hustar = hstar*ustar\n",
+    "        if plot_1:\n",
+    "            hu = shallow_water.hugoniot_locus(h,hstar,hustar,wave_family=1)\n",
+    "            u = hu/h\n",
+    "            plt.plot(h,u,'-',color='coral')\n",
+    "        if plot_2:\n",
+    "            hu = shallow_water.hugoniot_locus(h,hstar,hustar,wave_family=2)\n",
+    "            u = hu/h\n",
+    "            plt.plot(h,u,'-',color='maroon')\n",
+    "        plt.axis((0,3,-3,3))\n",
+    "        plt.xlabel('depth h')\n",
+    "        plt.ylabel('velocity u')\n",
+    "        plt.title('Hugoniot loci')\n",
+    "    plt.show()\n",
+    "\n",
+    "interact(plot_hugoniot_loci_u);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that in this plane, the curves in each family are simply vertical translates of one another, and all curves asymptote to $\\pm \\infty$ as $h \\rightarrow 0$."
    ]
   },
   {
@@ -236,7 +283,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -250,14 +299,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Check the boxes to plot the characteristic families, and notice that the 1-characteristics impinge on the 1-shock; the 2-characteristics impinge on the 2-shock.  Thus these shocks satisfy the entropy condition."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Dam-break problem: all-shock solution\n",
     "Here's another example, which you might think of as modeling a dam that suddenly breaks.  The water is initially at rest on both sides, but much deeper on the left."
@@ -267,7 +322,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -281,7 +338,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Check the box to plot the 1-characteristics.  Notice that they don't impinge on the 1-shock; instead, the characteristics to either side of the shock are diverging away from it.  This shock does not satisfy the entropy condition and should be replaced with a rarefaction.  The corresponding Hugoniot locus is plotted with a dashed line to remind us that it is unphysical.\n",
     "\n",
@@ -351,33 +411,7 @@
     "We can think of \\eqref{SW:dh}-\\eqref{SW:dhu} as an initial value ODE;\n",
     "fixing the value of $\\tilde{q}$ at one point in the rarefaction wave\n",
     "determines the whole solution of \\eqref{SW:dh}-\\eqref{SW:dhu}.  We\n",
-    "refer to each of these solutions as an *integral curve*.\n",
-    "Below, we plot some of the curves for the shallow water system, defined by \\eqref{SW:dh}-\\eqref{SW:dhu}."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "N = 400\n",
-    "h, hu = np.meshgrid(np.linspace(0.1,6,N),np.linspace(-3,3,N))\n",
-    "g = 1.\n",
-    "u = hu/h\n",
-    "dh = np.ones_like(h)\n",
-    "dhu1 = u - np.sqrt(g*h)\n",
-    "dhu2 = u + np.sqrt(g*h)\n",
-    "fig, ax = plt.subplots(1,2,figsize=(8,4))\n",
-    "ax[0].streamplot(h,hu,dh,dhu1,density=1.,arrowstyle='-',color='b')\n",
-    "ax[0].set_xlabel('$x$'); ax[0].set_ylabel('$hu$'); ax[0].set_title('1-waves')\n",
-    "ax[1].streamplot(h,hu,dh,dhu2,density=1.,arrowstyle='-',color='b')\n",
-    "plt.axis('tight'); plt.xlabel('$x$'); plt.ylabel('$hu$');  ax[1].set_title('2-waves');\n",
-    "plt.tight_layout()"
+    "refer to each of these solutions as an *integral curve*."
    ]
   },
   {
@@ -407,27 +441,83 @@
     "w_2(q) & = u - 2 \\sqrt{gh}.\n",
     "\\end{align}\n",
     "\n",
-    "In other words, the trajectories plotted above are just the level curves of $w_1$ and $w_2$.  Observe:"
+    "In other words, the trajectories plotted above are just the level curves of $w_1$ and $w_2$.  \n",
+    "This allows us to easily plot the integral curves as a contour plot of $w_1$ or $w_2$:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "w1 = u + 2 * np.sqrt(g*h)\n",
-    "w2 = u - 2 * np.sqrt(g*h)\n",
-    "fig, ax = plt.subplots(1,2,figsize=(8,4))\n",
-    "ax[0].contour(h,hu,w1,200,colors='b',linestyles='solid')\n",
-    "ax[0].set_xlabel('$x$'); ax[0].set_ylabel('$hu$'); ax[0].set_title('1-waves')\n",
-    "ax[1].contour(h,hu,w2,200,colors='b',linestyles='solid');\n",
-    "plt.axis('tight'); plt.xlabel('$x$'); plt.ylabel('$hu$');  ax[1].set_title('2-waves');\n",
-    "plt.tight_layout()"
+    "def plot_int_curves(plot_1=True,plot_2=False):\n",
+    "    N = 400\n",
+    "    h, hu = np.meshgrid(np.linspace(0.01,3,N),np.linspace(-3,3,N))\n",
+    "    g = 1.\n",
+    "    u = hu/h\n",
+    "    w1 = u + 2 * np.sqrt(g*h)\n",
+    "    w2 = u - 2 * np.sqrt(g*h)\n",
+    "    if plot_1:\n",
+    "        clines = np.linspace(-4,6,21)\n",
+    "        plt.contour(h,hu,w1,clines,colors='coral',linestyles='solid')\n",
+    "    if plot_2:\n",
+    "        clines = np.linspace(-6,4,21)\n",
+    "        plt.contour(h,hu,w2,clines,colors='maroon',linestyles='solid')\n",
+    "\n",
+    "    plt.axis((0,3,-3,3))\n",
+    "    plt.xlabel('depth h')\n",
+    "    plt.ylabel('momentum hu')\n",
+    "    plt.title('Integral curves')\n",
+    "    plt.show()\n",
+    "\n",
+    "interact(plot_int_curves);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also plot the integral curves in the $h$--$u$ plane:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def plot_int_curves_u(plot_1=True,plot_2=False):\n",
+    "    N = 100\n",
+    "    h, u = np.meshgrid(np.linspace(0.01,3,N),np.linspace(-3,3,N))\n",
+    "    g = 1.\n",
+    "    w1 = u + 2 * np.sqrt(g*h)\n",
+    "    w2 = u - 2 * np.sqrt(g*h)\n",
+    "    if plot_1:\n",
+    "        clines = np.linspace(-4,6,21)\n",
+    "        plt.contour(h,u,w1,clines,colors='coral',linestyles='solid')\n",
+    "    if plot_2:\n",
+    "        clines = np.linspace(-6,4,21)\n",
+    "        plt.contour(h,u,w2,clines,colors='maroon',linestyles='solid')\n",
+    "\n",
+    "    plt.axis((0,3,-3,3))\n",
+    "    plt.xlabel('depth h')\n",
+    "    plt.ylabel('velocity u')\n",
+    "    plt.title('Integral curves')\n",
+    "    plt.show()\n",
+    "\n",
+    "interact(plot_int_curves_u);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that in this plane the integral curves of each family are simply vertical translates of one another due to the form of the functions $w_1$ and $w_2$.  Unlike the Hugoniot loci, the integral curves do not asymptote to $\\pm\\infty$ as $h \\rightarrow 0$ and instead approach a finite value. "
    ]
   },
   {
@@ -491,14 +581,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
     "q_l  = Primitive_State(Depth = 1.,\n",
-    "                      Velocity = -1.)\n",
+    "                      Velocity = -1)\n",
     "q_r = Primitive_State(Depth = 1.,\n",
-    "                      Velocity = 1.)\n",
+    "                      Velocity = 1)\n",
     "\n",
     "plot_riemann_SW(q_l,q_r)"
    ]
@@ -506,6 +598,16 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "*Note that the velocities can be changed to $2, -2$ and the cell above still works with resulting $h_m \\approx 0$, but it breaks for larger outflow velocities.  Say something here about how the $h$--$u$ phase plane plots of integral curves show the dry state solution?*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Dam-break problem: all-rarefaction solution\n",
     "Next let us revisit the problem above where we found that the all-shock solution was incorrect.  This time we'll try to find an all-rarefaction solution."
@@ -515,7 +617,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -529,7 +633,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Plot the 2-characteristics and notice that they cross each other within the 2-rarefaction.  This rarefaction is not physical and should be replaced with a shock; the corresponding integral curve is hence shown as a dashed line."
    ]
@@ -552,7 +659,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Dam-break problem: correct solution\n",
     "Below we plot (at last) the correct solution to the dam-break problem, involving a 1-rarefaction and a 2-shock.  Plot the characteristics and notice how each family behaves correctly with respect the corresponding wave in the Riemann solution."
@@ -562,7 +672,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -645,7 +757,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Implements some suggested changes to the notebook:

 - Add plots in the h-u plane, for both Hugoniot loci and integral curves
 - Make the integral curves with contour plots and get rid of the stream plots
 - Make the integral curve plots more similar to H. loci plots, selecting 1- and/or 2-waves
 
We should discuss whether to talk about dry states here or elsewhere.